### PR TITLE
Remove ocaml-migrate-parsetree

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,5 +26,4 @@ the list of differences between a pattern and a value.
   (metapp (>= 0.4.4))
   (metaquot (>= 0.3.0))
   (refl (>= 0.3.0))
-  (ocaml-migrate-parsetree (>= 1.5.0))
   (stdcompat (>= 10))))

--- a/pattern.opam
+++ b/pattern.opam
@@ -26,6 +26,5 @@ depends: [
   "metapp" {>= "0.4.4"}
   "metaquot" {>= "0.3.0"}
   "refl" {>= "0.3.0"}
-  "ocaml-migrate-parsetree" {>= "1.5.0"}
   "stdcompat" {>= "10"}
 ]

--- a/ppx/dune
+++ b/ppx/dune
@@ -5,5 +5,5 @@
   (preprocess (pps metaquot.ppx))
   (library_flags (-linkall))
   (flags -open Stdcompat)
-  (libraries compiler-libs ocaml-migrate-parsetree stdcompat metapp metaquot
+  (libraries compiler-libs stdcompat metapp metaquot
     ppxlib))


### PR DESCRIPTION
`ocaml-migrate-parsetree` has been deprecated and is now part of `ppxlib`